### PR TITLE
fix: reduce default font size and padding, re-style footer links

### DIFF
--- a/src/components/molecules/Card/ValuesCard.tsx
+++ b/src/components/molecules/Card/ValuesCard.tsx
@@ -8,11 +8,14 @@ const ValuesCard = ({ title, image, imageText, text }: Props) => {
     <>
       {/* Title Container */}
       <div className="mb-4 flex items-center space-x-2 lg:mb-0">
-        <h3 className="text-2xl font-semibold text-[#3686ff]">{title}</h3>
+        <h3 className="text-lg font-semibold text-[#3686ff] sm:text-2xl">
+          {title}
+        </h3>
         <Image alt={imageText} src={image} width={35} height={35} />
       </div>
+
       <p className="mb-4 hidden font-black text-[#3686ff] lg:block">___</p>
-      <p className="max-w-xl text-white lg:max-w-md">{text}</p>
+      <p className="max-w-xl text-sm text-white lg:max-w-md">{text}</p>
     </>
   )
 }

--- a/src/components/organisms/Footer/Footer.js
+++ b/src/components/organisms/Footer/Footer.js
@@ -783,16 +783,7 @@ export default function Footer() {
 
       <footer className="bg-black">
         <div className="mx-auto flex w-full max-w-screen-xl flex-col p-4 py-10">
-          <Link href="/" className="sm:hidden flex justify-center lg:hidden">
-            <ImageAtomLocal
-              ImageStyleProps="lg:h-12"
-              src={VirufyLogo}
-              alt="Virufy Logo"
-              imagesize=""
-              border=""
-            />
-          </Link>
-          <div className="absolute mx-12 mt-12 hidden w-56 justify-start lg:flex">
+          <div className="absolute mx-12 mt-4 hidden w-56 justify-start lg:flex">
             <Link href="/" onClick={() => setActiveLink('Home')}>
               <ImageAtomLocal
                 src={VirufyLogo}
@@ -803,31 +794,8 @@ export default function Footer() {
               />
             </Link>
           </div>
-          <ul className="mb-6 flex flex-wrap text-white lg:hidden">
-            <li className="sm:hidden my-1 flex w-full items-center justify-center">
-              <LinkAtom Routes={links1} Style="linkFooter" />
-            </li>
-            <li className="sm:hidden my-1 flex w-full items-center justify-center">
-              <div onClick={() => setShowModalCookiesPolicy(true)}>
-                <LinkAtom Routes={links2} Style="linkFooter" />
-              </div>
-            </li>
-            <li className="sm:hidden my-1 flex w-full items-center justify-center">
-              <LinkAtom Routes={links3} Style="linkFooter" />
-            </li>
-            <li className="sm:hidden my-1 flex w-full items-center justify-center">
-              <div onClick={() => setShowModalPrivacyPolicy(true)}>
-                <LinkAtom Routes={links4} Style="linkFooter" />
-              </div>
-            </li>
-            <li className="sm:hidden my-1 flex w-full items-center justify-center">
-              <div onClick={() => setShowModalMyInformation(true)}>
-                <LinkAtom Routes={links5} Style="linkFooter" />
-              </div>
-            </li>
-          </ul>
           <ul className="mb-6 hidden flex-wrap text-white lg:flex">
-            <li className="mt-16 space-x-10 flex w-full align-text-bottom justify-center">
+            <li className="mt-8 flex w-full justify-center space-x-6 align-text-bottom xl:space-x-10">
               {links1.map((link, index) => {
                 return(
                   <Link
@@ -848,7 +816,7 @@ export default function Footer() {
           <div className="flex w-full">
             <hr className="hidden lg:block mx-auto my-4 h-px w-11/12 rounded border-0 bg-white" />
           </div>
-          <li className="lg:my-6 space-x-2 underline lg:no-underline lg:space-x-6 flex text-white font-semibold w-full items-center justify-center">
+          <li className="flex w-full flex-wrap items-center justify-center space-x-2 text-xs font-semibold text-white sm:text-base lg:my-6 lg:space-x-6 lg:no-underline">
             <div onClick={() => setShowModalCookiesPolicy(true)}>
               <LinkAtom Routes={links2} Style={`text-[15px]`} />
             </div>

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -81,7 +81,7 @@ export default function AboutUsPage() {
                 </h2>
 
                 {/* Cards Container */}
-                <div className="grid grid-cols-1 grid-rows-6 gap-y-6 rounded-3xl bg-[#132d62] px-16 py-12 lg:grid lg:grid-cols-2 lg:grid-rows-3 lg:gap-y-16 lg:gap-x-20 lg:space-y-0 lg:px-20">
+                <div className="grid grid-cols-1 grid-rows-6 gap-y-6 rounded-3xl bg-[#132d62] px-8 py-16 sm:px-16 lg:grid lg:grid-cols-2 lg:grid-rows-3 lg:gap-y-16 lg:gap-x-20 lg:space-y-0 lg:px-20">
                   {valuesSection.cards.map((card) => (
                     <div key={card.title}>
                       <ValuesCard {...card} />
@@ -96,7 +96,7 @@ export default function AboutUsPage() {
           <section>
             {/* Privacy Container */}
             <div className="mx-auto max-w-xl px-10 text-center font-medium text-white opacity-95 lg:max-w-2xl">
-              <h2 className="mb-10 text-5xl font-normal">
+              <h2 className="mb-10 text-4xl font-normal sm:text-5xl">
                 {privacySection.title}
               </h2>
               {privacySection.texts.map((text, i) => (


### PR DESCRIPTION
- Fix overflowing elements in the `/about-us` page at Mobile S - 320px shown in the following screenshots.
- Page should now fill screen width at Mobile S - 320px.

![image](https://github.com/virufy6/virufy6.github.io/assets/27314227/3b22ead3-818c-42d3-bb19-030a5725453f)
![image](https://github.com/virufy6/virufy6.github.io/assets/27314227/df896bad-c951-416a-b672-dc9b521b58ad)
![image](https://github.com/virufy6/virufy6.github.io/assets/27314227/13e11096-0259-4557-ac06-aae9c4833d24)
